### PR TITLE
商品削除機能の追加

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -48,6 +48,12 @@ class ItemsController < ApplicationController
     @comment = Comment.new
   end
 
+  def destroy
+    @item = Item.find(params[:id])
+    @item.destroy
+    redirect_to root_path
+  end
+
   def bookmarks
     @bookmark = current_user.bookmark_items.includes(:user).recent
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -50,8 +50,13 @@ class ItemsController < ApplicationController
 
   def destroy
     @item = Item.find(params[:id])
-    @item.destroy
-    redirect_to root_path
+    if @item.destroy
+      flash[:notice] = "削除しました"
+      redirect_to root_path
+    else
+      flash[:notice] = "削除できませんでした"
+      render action: :show
+    end
   end
 
   def bookmarks

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,7 +1,7 @@
 class Item < ApplicationRecord
   has_many :images, dependent: :destroy
   accepts_nested_attributes_for :images, allow_destroy: true    #build使用のため
-  has_many :comments
+  has_many :comments, dependent: :destroy
   has_many :bookmarks, dependent: :destroy
   belongs_to :category, optional: true
   belongs_to :brand, optional: true

--- a/app/views/items/_main.html.haml
+++ b/app/views/items/_main.html.haml
@@ -85,7 +85,7 @@
               %li
                 編集する
               %li
-                削除する
+                = link_to "削除する", item_path(@item), method: :delete
         .item__content__top__comments
           -@comments.each do |c|
             .item__content__top__comments__title

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -8,4 +8,7 @@
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
   %body
+    -if flash[:notice]
+      .flash
+        = flash[:notice]
     = yield


### PR DESCRIPTION
## What
ログイン中のユーザーが商品詳細ページで自分の出品した商品を削除する機能の追加

## Why
ユーザー自身が出品した商品を能動的に管理できるようにするため

https://gyazo.com/5b7ba7aa27c0a6183fd5fdc1bf1e3f48
https://gyazo.com/957f96612bda6c20ec066b20442c8036
https://gyazo.com/513531703542b5072fb2f82a4b01b89a

